### PR TITLE
Return stmt fixes, null testcases, pool unit test

### DIFF
--- a/testcases/execution/test_binary.shp
+++ b/testcases/execution/test_binary.shp
@@ -29,3 +29,60 @@ class Main<p1> where
         return sum;
     }
 }
+
+class A<q1, q2> where
+    q1: [A<q1, q2>],
+    q2: [B<q2, q1>]
+{
+    f: B<q2, q1>;
+    fv: i32;
+
+    fn is_null(): bool
+    {
+        return f == null;
+    }
+
+    fn make_twin(value: i32)
+    {
+        f = new B<q2, q1>;
+        f.g = this;
+        f.gv = value;
+    }
+
+    fn twin_getter(): i32
+    {
+        if f == null {
+            return -1 as i32;
+        }
+
+        return f.gv;
+    }
+
+    fn twin_setter(new_value: i32)
+    {
+        if f == null {
+            return;
+        }
+
+        f.gv = new_value;
+    }
+
+    fn getter(): i32
+    {
+        return fv;
+    }
+
+    fn setter(new_value: i32)
+    {
+        fv = new_value;
+    }
+}
+
+class B<r1, r2> where
+    r1: [B<r1, r2>],
+    r2: [A<r2, r1>]
+{
+    g: A<r2, r1>;
+    gv: i32;
+}
+layout LB: B = rec{g} + rec{gv};

--- a/testcases/semantic_error/null1.shp
+++ b/testcases/semantic_error/null1.shp
@@ -1,0 +1,10 @@
+class Main<p1> where
+    p1: [Main<p1>]
+{
+    f: i32;
+
+    fn identity(x: i32): i32
+    {
+        return null;
+    }
+}

--- a/testcases/semantic_error/null2.shp
+++ b/testcases/semantic_error/null2.shp
@@ -1,0 +1,14 @@
+class Main<p1> where
+    p1: [Main<p1>]
+{
+    f: i32;
+
+    fn foo(x: i32)
+    {
+    }
+
+    fn bar()
+    {
+        foo(null);
+    }
+}

--- a/testcases/semantic_error/null3.shp
+++ b/testcases/semantic_error/null3.shp
@@ -1,0 +1,11 @@
+class Main<p1> where
+    p1: [Main<p1>]
+{
+    f: i32;
+
+    fn setter()
+    {
+        f = null;
+    }
+
+}

--- a/testcases/valid/linked_list.shp
+++ b/testcases/valid/linked_list.shp
@@ -1,0 +1,42 @@
+class List<p1, p2> where
+    p1: [List<p1, p2>],
+    p2: [ListElem<p2>],
+{
+    next: List<p1, p2>;
+    item: ListElem<p2>;
+
+    fn set_item(new_item: ListElem<p2>)
+    {
+        item = new_item;
+    }
+
+    fn cons(head_item: ListElem<p2>, tail: List<p1, p2>): List<p1, p2>
+    {
+        let retval: List<p1, p2>;
+        retval = new List<p1, p2>;
+
+        retval.next = tail;
+        retval.item = head_item;
+
+        return retval;
+    }
+}
+
+class ListElem<p> where
+    p: [ListElem<p>]
+{
+    value: i32;
+
+    fn setter(value: i32)
+    {
+        this.value = value;
+    }
+
+    fn getter(): i32
+    {
+        return value;
+    }
+}
+
+layout SoaList: List = rec{next} + rec{item};
+layout AosList: List = rec{next, item};

--- a/testcases/valid/null.shp
+++ b/testcases/valid/null.shp
@@ -1,0 +1,25 @@
+class Main<p1> where
+    p1: [Main<p1>]
+{
+    f: Main<p1>;
+
+    fn setter_null()
+    {
+        f = null;
+    }
+
+    fn setter(x: Main<p1>)
+    {
+        f = x;
+        this.f = x;
+    }
+
+    fn getter(): Main<p1>
+    {
+        if f == null {
+            return null;
+        }
+
+        return f;
+    }
+}


### PR DESCRIPTION
* Fixed assertion error regarding codegen of `return null` statements.
* Added testcases to catch semantic errors regarding null typechecking.
* Added rudimentary unit test that tests generation and mutation of pooled objects.